### PR TITLE
Fix setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,4 +50,4 @@ If an update is found, a notification is sent. In addition, a desktop
 widget show the latest entry of all feeds and for each feed, a widget
 shows all entries.
 """,
-      install_requires=["babel", "beautifulsoup4", "feedparser", 'pillow', 'dateutil', 'ewmh'])
+      install_requires=["babel", "beautifulsoup4", "feedparser", 'pillow', 'python-dateutil', 'ewmh'])


### PR DESCRIPTION
Correct name of the dateutil library in the install requirements in setup.py. 
Fix #7.